### PR TITLE
Use upx in docker build to slim down executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
+FROM alpine:3.10.3 as compressor
+
+WORKDIR ./
+RUN apk add upx
+
+COPY ./bin/edge-agent ./
+RUN upx --best --lzma ./edge-agent
+
 FROM alpine:3.10.3
 
 RUN addgroup -S warrant-edge && adduser -S warrant-edge -G warrant-edge
 USER warrant-edge
 
 WORKDIR ./
-COPY ./bin/edge-agent ./
+COPY --from=compressor ./edge-agent ./
 
 ENTRYPOINT ["./edge-agent"]
 


### PR DESCRIPTION
# Brief
This PR alters the Dockerfile to run the `edge-agent` binary through the [upx](https://upx.github.io/) packer in a separate build layer, resulting in a reduction of ~10MiB.

The binary is small as-is, but hey, it's free real estate.

```
REPOSITORY              TAG       IMAGE ID       CREATED        SIZE
warrantdev/edge-agent   upx       28db3e8eefcb   8 hours ago    10.4MB
warrantdev/edge-agent   latest    1a66f976d117   3 months ago   20.9MB
```